### PR TITLE
Parse event uri

### DIFF
--- a/processors/container_metric_processor.go
+++ b/processors/container_metric_processor.go
@@ -1,10 +1,9 @@
 package processors
 
 import (
-	"strconv"
-
 	"github.com/cloudfoundry/noaa/events"
 	"github.com/pivotal-cf/graphite-nozzle/metrics"
+	"strconv"
 )
 
 type ContainerMetricProcessor struct{}
@@ -13,7 +12,7 @@ func NewContainerMetricProcessor() *ContainerMetricProcessor {
 	return &ContainerMetricProcessor{}
 }
 
-func (p *ContainerMetricProcessor) Process(e *events.Envelope) []metrics.Metric {
+func (p *ContainerMetricProcessor) Process(e *events.Envelope) ([]metrics.Metric, error) {
 	processedMetrics := make([]metrics.Metric, 3)
 	containerMetricEvent := e.GetContainerMetric()
 
@@ -21,7 +20,7 @@ func (p *ContainerMetricProcessor) Process(e *events.Envelope) []metrics.Metric 
 	processedMetrics[1] = metrics.Metric(p.ProcessContainerMetricMemory(containerMetricEvent))
 	processedMetrics[2] = metrics.Metric(p.ProcessContainerMetricDisk(containerMetricEvent))
 
-	return processedMetrics
+	return processedMetrics, nil
 }
 
 func (p *ContainerMetricProcessor) ProcessContainerMetricCPU(e *events.ContainerMetric) metrics.GaugeMetric {

--- a/processors/container_metric_processor_test.go
+++ b/processors/container_metric_processor_test.go
@@ -39,8 +39,9 @@ var _ = Describe("ContainerMetricProcessor", func() {
 
 	Describe("#Process", func() {
 		It("returns a Metric for each of the ProcessContainerMetric* methods", func() {
-			processedMetrics := processor.Process(event)
+			processedMetrics, err := processor.Process(event)
 
+			Expect(err).To(BeNil())
 			Expect(processedMetrics).To(HaveLen(3))
 		})
 	})

--- a/processors/counter_processor.go
+++ b/processors/counter_processor.go
@@ -11,13 +11,13 @@ func NewCounterProcessor() *CounterProcessor {
 	return &CounterProcessor{}
 }
 
-func (p *CounterProcessor) Process(e *events.Envelope) []metrics.Metric {
+func (p *CounterProcessor) Process(e *events.Envelope) ([]metrics.Metric, error) {
 	processedMetrics := make([]metrics.Metric, 1)
 	counterEvent := e.GetCounterEvent()
 
 	processedMetrics[0] = metrics.Metric(p.ProcessCounter(counterEvent))
 
-	return processedMetrics
+	return processedMetrics, nil
 }
 
 func (p *CounterProcessor) ProcessCounter(event *events.CounterEvent) *metrics.CounterMetric {

--- a/processors/counter_processor_test.go
+++ b/processors/counter_processor_test.go
@@ -34,8 +34,9 @@ var _ = Describe("CounterEventProcessor", func() {
 
 	Describe("#Process", func() {
 		It("returns a Metric for each of the ProcessCounter* methods", func() {
-			processedMetrics := processor.Process(event)
+			processedMetrics, err := processor.Process(event)
 
+			Expect(err).To(BeNil())
 			Expect(processedMetrics).To(HaveLen(1))
 		})
 	})

--- a/processors/heartbeat_processor.go
+++ b/processors/heartbeat_processor.go
@@ -11,7 +11,7 @@ func NewHeartbeatProcessor() *HeartbeatProcessor {
 	return &HeartbeatProcessor{}
 }
 
-func (p *HeartbeatProcessor) Process(e *events.Envelope) []metrics.Metric {
+func (p *HeartbeatProcessor) Process(e *events.Envelope) ([]metrics.Metric, error) {
 	processedMetrics := make([]metrics.Metric, 4)
 	heartbeat := e.GetHeartbeat()
 	origin := e.GetOrigin()
@@ -21,7 +21,7 @@ func (p *HeartbeatProcessor) Process(e *events.Envelope) []metrics.Metric {
 	processedMetrics[2] = metrics.Metric(p.ProcessHeartbeatEventsReceivedCount(heartbeat, origin))
 	processedMetrics[3] = metrics.Metric(p.ProcessHeartbeatEventsErrorCount(heartbeat, origin))
 
-	return processedMetrics
+	return processedMetrics, nil
 }
 
 func (p *HeartbeatProcessor) ProcessHeartbeatCount(e *events.Heartbeat, origin string) *metrics.CounterMetric {

--- a/processors/heartbeat_processor_test.go
+++ b/processors/heartbeat_processor_test.go
@@ -38,8 +38,9 @@ var _ = Describe("Heartbeat", func() {
 
 	Describe("#Process", func() {
 		It("returns a Metric for each of the ProcessHeartbeat* methods", func() {
-			processedMetrics := processor.Process(event)
+			processedMetrics, err := processor.Process(event)
 
+			Expect(err).To(BeNil())
 			Expect(processedMetrics).To(HaveLen(4))
 		})
 	})

--- a/processors/http_start_stop_processor.go
+++ b/processors/http_start_stop_processor.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"github.com/cloudfoundry/noaa/events"
 	"github.com/pivotal-cf/graphite-nozzle/metrics"
-	"net/url"
 	"strconv"
 	"strings"
 )
@@ -42,15 +41,23 @@ func (p *HttpStartStopProcessor) Process(e *events.Envelope) (processedMetrics [
 	return
 }
 
-func (p *HttpStartStopProcessor) parseEventUri(uri string) string {
-	parsed_uri, err := url.Parse(uri)
-	if err != nil {
-		panic(err)
-	}
 
-	hostname := strings.Replace(parsed_uri.Host, ".", "_", -1)
+//we want to be able to parse events whether they contain the scheme
+//element in their uri field or not
+func (p *HttpStartStopProcessor) parseEventUri(uri string) string {
+
+  hostname := ""
+
+  //we first remove the scheme
+  if strings.Contains(uri, "://") {
+  	uri = strings.Split(uri, "://")[1]
+  }
+
+  //and then proceed with extracting the hostname
+  hostname = strings.Replace(strings.Split(uri, "/")[0], ".", "_", -1)
+
 	if !(len(hostname) > 0) {
-		panic(errors.New("Hostname cannot be extracted from Event"))
+		panic(errors.New("Hostname cannot be extracted from Event uri: " + uri))
 	}
 
 	return hostname

--- a/processors/http_start_stop_processor.go
+++ b/processors/http_start_stop_processor.go
@@ -1,11 +1,12 @@
 package processors
 
 import (
-	"strconv"
-	"strings"
-
+	"errors"
 	"github.com/cloudfoundry/noaa/events"
 	"github.com/pivotal-cf/graphite-nozzle/metrics"
+	"net/url"
+	"strconv"
+	"strings"
 )
 
 type HttpStartStopProcessor struct{}
@@ -23,12 +24,26 @@ func (p *HttpStartStopProcessor) Process(e *events.Envelope) []metrics.Metric {
 	processedMetrics[2] = metrics.Metric(p.ProcessHttpStartStopHttpErrorCount(httpStartStopEvent))
 	processedMetrics[3] = metrics.Metric(p.ProcessHttpStartStopHttpRequestCount(httpStartStopEvent))
 
-	return processedMetrics
+	return
+}
+
+func (p *HttpStartStopProcessor) parseEventUri(uri string) string {
+	parsed_uri, err := url.Parse(uri)
+	if err != nil {
+		panic(err)
+	}
+
+	hostname := strings.Replace(parsed_uri.Host, ".", "_", -1)
+	if !(len(hostname) > 0) {
+		panic(errors.New("Hostname cannot be extracted from Event"))
+	}
+
+	return hostname
 }
 
 func (p *HttpStartStopProcessor) ProcessHttpStartStopResponseTime(event *events.HttpStartStop) *metrics.TimingMetric {
 	statPrefix := "http.responsetimes."
-	hostname := strings.Replace(strings.Split(event.GetUri(), "/")[0], ".", "_", -1)
+	hostname := p.parseEventUri(event.GetUri())
 	stat := statPrefix + hostname
 
 	startTimestamp := event.GetStartTimestamp()
@@ -42,7 +57,7 @@ func (p *HttpStartStopProcessor) ProcessHttpStartStopResponseTime(event *events.
 
 func (p *HttpStartStopProcessor) ProcessHttpStartStopStatusCodeCount(event *events.HttpStartStop) *metrics.CounterMetric {
 	statPrefix := "http.statuscodes."
-	hostname := strings.Replace(strings.Split(event.GetUri(), "/")[0], ".", "_", -1)
+	hostname := p.parseEventUri(event.GetUri())
 	stat := statPrefix + hostname + "." + strconv.Itoa(int(event.GetStatusCode()))
 
 	metric := metrics.NewCounterMetric(stat, isPeer(event))
@@ -54,7 +69,7 @@ func (p *HttpStartStopProcessor) ProcessHttpStartStopHttpErrorCount(event *event
 	var incrementValue int64
 
 	statPrefix := "http.errors."
-	hostname := strings.Replace(strings.Split(event.GetUri(), "/")[0], ".", "_", -1)
+	hostname := p.parseEventUri(event.GetUri())
 	stat := statPrefix + hostname
 
 	if 299 < event.GetStatusCode() && 1 == isPeer(event) {
@@ -70,7 +85,7 @@ func (p *HttpStartStopProcessor) ProcessHttpStartStopHttpErrorCount(event *event
 
 func (p *HttpStartStopProcessor) ProcessHttpStartStopHttpRequestCount(event *events.HttpStartStop) *metrics.CounterMetric {
 	statPrefix := "http.requests."
-	hostname := strings.Replace(strings.Split(event.GetUri(), "/")[0], ".", "_", -1)
+	hostname := p.parseEventUri(event.GetUri())
 	stat := statPrefix + hostname
 	metric := metrics.NewCounterMetric(stat, isPeer(event))
 

--- a/processors/http_start_stop_processor.go
+++ b/processors/http_start_stop_processor.go
@@ -54,7 +54,9 @@ func (p *HttpStartStopProcessor) parseEventUri(uri string) string {
   }
 
   //and then proceed with extracting the hostname
-  hostname = strings.Replace(strings.Split(uri, "/")[0], ".", "_", -1)
+  hostname = strings.Split(uri, "/")[0]
+  hostname = strings.Replace(hostname, ".", "_", -1)
+  hostname = strings.Replace(hostname, ":", "_", -1)
 
 	if !(len(hostname) > 0) {
 		panic(errors.New("Hostname cannot be extracted from Event uri: " + uri))

--- a/processors/http_start_stop_processor.go
+++ b/processors/http_start_stop_processor.go
@@ -15,8 +15,23 @@ func NewHttpStartStopProcessor() *HttpStartStopProcessor {
 	return &HttpStartStopProcessor{}
 }
 
-func (p *HttpStartStopProcessor) Process(e *events.Envelope) []metrics.Metric {
-	processedMetrics := make([]metrics.Metric, 4)
+func (p *HttpStartStopProcessor) Process(e *events.Envelope) (processedMetrics []metrics.Metric, err error) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			switch x := r.(type) {
+			case string:
+				err = errors.New(x)
+			case error:
+				err = x
+			default:
+				err = errors.New("Unknown error")
+			}
+			processedMetrics = nil
+		}
+	}()
+
+	processedMetrics = make([]metrics.Metric, 4)
 	httpStartStopEvent := e.GetHttpStartStop()
 
 	processedMetrics[0] = metrics.Metric(p.ProcessHttpStartStopResponseTime(httpStartStopEvent))

--- a/processors/http_start_stop_processor_test.go
+++ b/processors/http_start_stop_processor_test.go
@@ -27,7 +27,7 @@ var _ = Describe("HttpStartStopProcessor", func() {
 		startTimestamp = int64(1425881484152112140)
 		stopTimestamp = int64(1425881484161498528)
 		method = events.Method_GET
-		uri = "http://api.10.244.0.34.xip.io/v2/info"
+		uri = "http://api.10.244.0.34.xip.io:443/v2/info"
 		statusCode = int32(200)
 		peerType = events.PeerType_Client
 	})
@@ -61,7 +61,7 @@ var _ = Describe("HttpStartStopProcessor", func() {
 
 		Context("with a properly formatted event which does not contain the schema", func() {
 			BeforeEach(func() {
-				uri = "api.10.244.0.34.xip.io/v2/info"
+				uri = "api.10.244.0.34.xip.io/v2/info:443"
 			})
 			It("returns a Metric for each of the ProcessHttpStartStop* methods", func() {
 				processedMetrics, err := processor.Process(event)
@@ -89,7 +89,7 @@ var _ = Describe("HttpStartStopProcessor", func() {
 		It("formats the Stat string to include the hostname", func() {
 			metric := processor.ProcessHttpStartStopResponseTime(httpStartStopEvent)
 
-			Expect(metric.Stat).To(Equal("http.responsetimes.api_10_244_0_34_xip_io"))
+			Expect(metric.Stat).To(Equal("http.responsetimes.api_10_244_0_34_xip_io_443"))
 		})
 
 		It("calculates the HTTP response time in milliseconds", func() {
@@ -104,18 +104,18 @@ var _ = Describe("HttpStartStopProcessor", func() {
 			It("formats the Stat string to include the hostname and the status code", func() {
 				metric := processor.ProcessHttpStartStopStatusCodeCount(httpStartStopEvent)
 
-				Expect(metric.Stat).To(Equal("http.statuscodes.api_10_244_0_34_xip_io.200"))
+				Expect(metric.Stat).To(Equal("http.statuscodes.api_10_244_0_34_xip_io_443.200"))
 			})
 
 			It("it does not increment the error counter by one", func() {
 				metric := processor.ProcessHttpStartStopHttpErrorCount(httpStartStopEvent)
-				Expect(metric.Stat).To(Equal("http.errors.api_10_244_0_34_xip_io"))
+				Expect(metric.Stat).To(Equal("http.errors.api_10_244_0_34_xip_io_443"))
 				Expect(metric.Value).To(Equal(int64(0)))
 			})
 
 			It("increments the requests counter by one", func() {
 				metric := processor.ProcessHttpStartStopHttpRequestCount(httpStartStopEvent)
-				Expect(metric.Stat).To(Equal("http.requests.api_10_244_0_34_xip_io"))
+				Expect(metric.Stat).To(Equal("http.requests.api_10_244_0_34_xip_io_443"))
 				Expect(metric.Value).To(Equal(int64(1)))
 			})
 		})
@@ -126,14 +126,14 @@ var _ = Describe("HttpStartStopProcessor", func() {
 				httpStartStopEvent.StatusCode = &statusCode
 				metric := processor.ProcessHttpStartStopStatusCodeCount(httpStartStopEvent)
 
-				Expect(metric.Stat).To(Equal("http.statuscodes.api_10_244_0_34_xip_io.404"))
+				Expect(metric.Stat).To(Equal("http.statuscodes.api_10_244_0_34_xip_io_443.404"))
 			})
 
 			It("increments the error counter by one", func() {
 				statusCode := int32(404)
 				httpStartStopEvent.StatusCode = &statusCode
 				metric := processor.ProcessHttpStartStopHttpErrorCount(httpStartStopEvent)
-				Expect(metric.Stat).To(Equal("http.errors.api_10_244_0_34_xip_io"))
+				Expect(metric.Stat).To(Equal("http.errors.api_10_244_0_34_xip_io_443"))
 				Expect(metric.Value).To(Equal(int64(1)))
 			})
 
@@ -141,7 +141,7 @@ var _ = Describe("HttpStartStopProcessor", func() {
 				statusCode := int32(404)
 				httpStartStopEvent.StatusCode = &statusCode
 				metric := processor.ProcessHttpStartStopHttpRequestCount(httpStartStopEvent)
-				Expect(metric.Stat).To(Equal("http.requests.api_10_244_0_34_xip_io"))
+				Expect(metric.Stat).To(Equal("http.requests.api_10_244_0_34_xip_io_443"))
 				Expect(metric.Value).To(Equal(int64(1)))
 			})
 		})

--- a/processors/http_start_stop_processor_test.go
+++ b/processors/http_start_stop_processor_test.go
@@ -50,7 +50,19 @@ var _ = Describe("HttpStartStopProcessor", func() {
 	})
 
 	Describe("#Process", func() {
-		Context("The Event is properly formatted", func() {
+		Context("with a properly formatted event which contains the schema", func() {
+			It("returns a Metric for each of the ProcessHttpStartStop* methods", func() {
+				processedMetrics, err := processor.Process(event)
+
+				Expect(err).To(BeNil())
+				Expect(processedMetrics).To(HaveLen(4))
+			})
+		})
+
+		Context("with a properly formatted event which does not contain the schema", func() {
+			BeforeEach(func() {
+				uri = "api.10.244.0.34.xip.io/v2/info"
+			})
 			It("returns a Metric for each of the ProcessHttpStartStop* methods", func() {
 				processedMetrics, err := processor.Process(event)
 
@@ -60,14 +72,8 @@ var _ = Describe("HttpStartStopProcessor", func() {
 		})
 
 		Context("the Event uri field is empty", func() {
-
 			BeforeEach(func() {
-				startTimestamp = int64(1425881484152112140)
-				stopTimestamp = int64(1425881484161498528)
-				method = events.Method_GET
 				uri = ""
-				statusCode = int32(200)
-				peerType = events.PeerType_Client
 			})
 
 			It("returns an error", func() {

--- a/processors/processor.go
+++ b/processors/processor.go
@@ -6,5 +6,5 @@ import (
 )
 
 type Processor interface {
-	Process(e *events.Envelope) []metrics.Metric
+	Process(e *events.Envelope) ([]metrics.Metric, error)
 }

--- a/processors/value_metric_processor.go
+++ b/processors/value_metric_processor.go
@@ -11,13 +11,13 @@ func NewValueMetricProcessor() *ValueMetricProcessor {
 	return &ValueMetricProcessor{}
 }
 
-func (p *ValueMetricProcessor) Process(e *events.Envelope) []metrics.Metric {
+func (p *ValueMetricProcessor) Process(e *events.Envelope) ([]metrics.Metric, error) {
 	processedMetrics := make([]metrics.Metric, 1)
 	valueMetricEvent := e.GetValueMetric()
 
 	processedMetrics[0] = p.ProcessValueMetric(valueMetricEvent, e.GetOrigin())
 
-	return processedMetrics
+	return processedMetrics, nil
 }
 
 func (p *ValueMetricProcessor) ProcessValueMetric(event *events.ValueMetric, origin string) *metrics.FGaugeMetric {

--- a/processors/value_metric_processor_test.go
+++ b/processors/value_metric_processor_test.go
@@ -39,8 +39,9 @@ var _ = Describe("ValueMetricProcessor", func() {
 
 	Describe("#Process", func() {
 		It("returns a Metric for each of the ProcessValueMetric* methods", func() {
-			processedMetrics := processor.Process(event)
+			processedMetrics, err := processor.Process(event)
 
+			Expect(err).To(BeNil())
 			Expect(processedMetrics).To(HaveLen(1))
 		})
 	})


### PR DESCRIPTION
Hi!

Since working with the nozzle in our CF installation we have been hitting this problem:  [uri parsing issue](https://github.com/pivotal-cf/graphite-nozzle/issues/9).

In our case both events containing the scheme (ie: http://my.app/v2) and without it (ie: my.app/v2) are generated and the following line for parsing them:

`hostname := strings.Replace(strings.Split(event.GetUri(), "/")[0], ".", "_", -1)`

just comes short in accounting for both the cases.

In re-factoring the code I've taken into account and tested the performance of the proposed solution which showed comparable execution time to the old one.

The code solves primarily an issue I've been experiencing and  has been written following this premise and perhaps with a limited understanding of other installations and requirements.

Feel free to comment it and use or modify at your discretion.

Thanks
Claudio