### PR TITLE
Remove Println of UAA credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,9 +33,6 @@ var (
 func main() {
 	kingpin.Parse()
 
-	fmt.Println(*uaaEndpoint)
-	fmt.Println(*username)
-	fmt.Println(*password)
 	tokenFetcher := &token.UAATokenFetcher{
 		UaaUrl:                *uaaEndpoint,
 		Username:              *username,


### PR DESCRIPTION
No app should print its credentials to the stdout or log.
I guess this was a leftover of development testing, so I will
remove it.