### PR TITLE
Enable tcp protocol for statsd

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/pivotal-cf/graphite-nozzle",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v74",
+	"GodepVersion": "v79",
 	"Packages": [
 		"."
 	],
@@ -45,11 +45,11 @@
 		},
 		{
 			"ImportPath": "github.com/quipo/statsd",
-			"Rev": "1090ab4693b587d42fbf75c2cc64a031a9f22a4b"
+			"Rev": "39c3fe59a6c334d5aefddf41f3c16595301c80e1"
 		},
 		{
 			"ImportPath": "github.com/quipo/statsd/event",
-			"Rev": "1090ab4693b587d42fbf75c2cc64a031a9f22a4b"
+			"Rev": "39c3fe59a6c334d5aefddf41f3c16595301c80e1"
 		},
 		{
 			"ImportPath": "gopkg.in/alecthomas/kingpin.v2",

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ var (
 	subscriptionId    = kingpin.Flag("subscription-id", "Id for the subscription.").Default("firehose").OverrideDefaultFromEnvar("SUBSCRIPTION_ID").String()
 	statsdEndpoint    = kingpin.Flag("statsd-endpoint", "Statsd endpoint").Default("10.244.11.2:8125").OverrideDefaultFromEnvar("STATSD_ENDPOINT").String()
 	statsdPrefix      = kingpin.Flag("statsd-prefix", "Statsd prefix").Default("mycf.").OverrideDefaultFromEnvar("STATSD_PREFIX").String()
+	statsdProtocol      = kingpin.Flag("statsd-protocol", "Statsd protocol, either udp or tcp").Default("udp").OverrideDefaultFromEnvar("STATSD_PROTOCOL").String()
 	prefixJob         = kingpin.Flag("prefix-job", "Prefix metric names with job.index").Default("false").OverrideDefaultFromEnvar("PREFIX_JOB").Bool()
 	username          = kingpin.Flag("username", "Firehose username.").Default("admin").OverrideDefaultFromEnvar("FIREHOSE_USERNAME").String()
 	password          = kingpin.Flag("password", "Firehose password.").Default("admin").OverrideDefaultFromEnvar("FIREHOSE_PASSWORD").String()
@@ -32,6 +33,12 @@ var (
 
 func main() {
 	kingpin.Parse()
+
+	err := ValidateStatsdProtocol(*statsdProtocol)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
 
 	tokenFetcher := &token.UAATokenFetcher{
 		UaaUrl:                *uaaEndpoint,
@@ -54,8 +61,17 @@ func main() {
 	heartbeatProcessor := processors.NewHeartbeatProcessor()
 	counterProcessor := processors.NewCounterProcessor()
 
+	//Initialising statsd sender
 	sender := statsd.NewStatsdClient(*statsdEndpoint, *statsdPrefix)
-	sender.CreateSocket()
+
+	switch 	statsdProtocol := *statsdProtocol; statsdProtocol {
+		case "udp":
+			sender.CreateSocket()
+			fmt.Println("Using udp protocol for statsd")
+		case "tcp":
+			sender.CreateTCPSocket()
+			fmt.Println("Using tcp protocol for statsd")
+	}
 
 	var processedMetrics []metrics.Metric
 	var proc_err error

--- a/validators.go
+++ b/validators.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"errors"
+)
+
+func ValidateStatsdProtocol(statsdProtocol string) (err error) {
+	err_msg := "Statsd protocol needs to be one of: ['tcp', 'udp']"
+	switch statsdProtocol {
+ 		case "udp", "tcp":
+ 			err = nil
+		default:
+			err = errors.New(err_msg)
+	}
+
+	return err
+}

--- a/vendor/github.com/quipo/statsd/README.md
+++ b/vendor/github.com/quipo/statsd/README.md
@@ -29,7 +29,9 @@ This client library was inspired by the one embedded in the [Bit.ly NSQ](https:/
 package main
 
 import (
-    "time"
+	"log"
+	"os"
+	"time"
 
 	"github.com/quipo/statsd"
 )
@@ -38,7 +40,11 @@ func main() {
 	// init
 	prefix := "myproject."
 	statsdclient := statsd.NewStatsdClient("localhost:8125", prefix)
-	statsdclient.CreateSocket()
+	err := statsdclient.CreateSocket()
+	if nil != err {
+		log.Println(err)
+		os.Exit(1)
+	}
 	interval := time.Second * 2 // aggregate stats and flush every 2 seconds
 	stats := statsd.NewStatsdBuffer(interval, statsdclient)
 	defer stats.Close()

--- a/vendor/github.com/quipo/statsd/client.go
+++ b/vendor/github.com/quipo/statsd/client.go
@@ -16,8 +16,20 @@ type Logger interface {
 	Println(v ...interface{})
 }
 
-// note Hostname is exported so clients can set it to something different than the default
+// UDPPayloadSize is the number of bytes to send at one go through the udp socket.
+// SendEvents will try to pack as many events into one udp packet.
+// Change this value as per network capabilities
+// For example to change to 16KB
+//  import "github.com/quipo/statsd"
+//  func init() {
+//   statsd.UDPPayloadSize = 16 * 1024
+//  }
+var UDPPayloadSize int = 512
+
+// Hostname is exported so clients can set it to something different than the default
 var Hostname string
+
+var errNotConnected = fmt.Errorf("cannot send stats, not connected to StatsD server")
 
 func init() {
 	host, err := os.Hostname()
@@ -28,10 +40,11 @@ func init() {
 
 // StatsdClient is a client library to send events to StatsD
 type StatsdClient struct {
-	conn   net.Conn
-	addr   string
-	prefix string
-	Logger Logger
+	conn           net.Conn
+	addr           string
+	prefix         string
+	eventStringTpl string
+	Logger         Logger
 }
 
 // NewStatsdClient - Factory
@@ -39,9 +52,10 @@ func NewStatsdClient(addr string, prefix string) *StatsdClient {
 	// allow %HOST% in the prefix string
 	prefix = strings.Replace(prefix, "%HOST%", Hostname, 1)
 	return &StatsdClient{
-		addr:   addr,
-		prefix: prefix,
-		Logger: log.New(os.Stdout, "[StatsdClient] ", log.Ldate|log.Ltime),
+		addr:           addr,
+		prefix:         prefix,
+		Logger:         log.New(os.Stdout, "[StatsdClient] ", log.Ldate|log.Ltime),
+		eventStringTpl: "%s%s:%s",
 	}
 }
 
@@ -57,6 +71,17 @@ func (c *StatsdClient) CreateSocket() error {
 		return err
 	}
 	c.conn = conn
+	return nil
+}
+
+// CreateTCPSocket creates a TCP connection to a StatsD server
+func (c *StatsdClient) CreateTCPSocket() error {
+	conn, err := net.DialTimeout("tcp", c.addr, 5*time.Second)
+	if err != nil {
+		return err
+	}
+	c.conn = conn
+	c.eventStringTpl = "%s%s:%s\n"
 	return nil
 }
 
@@ -96,7 +121,7 @@ func (c *StatsdClient) Timing(stat string, delta int64) error {
 // PrecisionTiming - Track a duration event
 // the time delta has to be a duration
 func (c *StatsdClient) PrecisionTiming(stat string, delta time.Duration) error {
-	return c.send(stat, fmt.Sprintf("%.6f%s|ms", float64(delta)/float64(time.Millisecond), "%d"), 0)
+	return c.send(stat, "%.6f|ms", float64(delta)/float64(time.Millisecond))
 }
 
 // Gauge - Gauges are a constant data type. They are not subject to averaging,
@@ -157,10 +182,11 @@ func (c *StatsdClient) Total(stat string, value int64) error {
 // write a UDP packet with the statsd event
 func (c *StatsdClient) send(stat string, format string, value interface{}) error {
 	if c.conn == nil {
-		return fmt.Errorf("not connected")
+		return errNotConnected
 	}
 	stat = strings.Replace(stat, "%HOST%", Hostname, 1)
-	format = fmt.Sprintf("%s%s:%s", c.prefix, stat, format)
+	// if sending tcp append a newline
+	format = fmt.Sprintf(c.eventStringTpl, c.prefix, stat, format)
 	_, err := fmt.Fprintf(c.conn, format, value)
 	return err
 }
@@ -168,14 +194,56 @@ func (c *StatsdClient) send(stat string, format string, value interface{}) error
 // SendEvent - Sends stats from an event object
 func (c *StatsdClient) SendEvent(e event.Event) error {
 	if c.conn == nil {
-		return fmt.Errorf("cannot send stats, not connected to StatsD server")
+		return errNotConnected
 	}
 	for _, stat := range e.Stats() {
-		//fmt.Printf("SENDING EVENT %s%s\n", c.prefix, stat)
-		_, err := fmt.Fprintf(c.conn, "%s%s", c.prefix, stat)
+		//fmt.Printf("SENDING EVENT %s%s\n", c.prefix, strings.Replace(stat, "%HOST%", Hostname, 1))
+		_, err := fmt.Fprintf(c.conn, "%s%s", c.prefix, strings.Replace(stat, "%HOST%", Hostname, 1))
 		if nil != err {
 			return err
 		}
 	}
+	return nil
+}
+
+// SendEvents - Sends stats from all the event objects.
+// Tries to bundle many together into one fmt.Fprintf based on UDPPayloadSize.
+func (c *StatsdClient) SendEvents(events map[string]event.Event) error {
+	if c.conn == nil {
+		return errNotConnected
+	}
+
+	var n int
+	var stats []string = make([]string, 0)
+
+	for _, e := range events {
+		for _, stat := range e.Stats() {
+
+			stat = fmt.Sprintf("%s%s", c.prefix, strings.Replace(stat, "%HOST%", Hostname, 1))
+			_n := n + len(stat) + 1
+
+			if _n > UDPPayloadSize {
+				// with this last event, the UDP payload would be too big
+				if _, err := fmt.Fprintf(c.conn, strings.Join(stats, "\n")); err != nil {
+					return err
+				}
+				// reset payload after flushing, and add the last event
+				stats = []string{stat}
+				n = len(stat)
+				continue
+			}
+
+			// can fit more into the current payload
+			n = _n
+			stats = append(stats, stat)
+		}
+	}
+
+	if len(stats) != 0 {
+		if _, err := fmt.Fprintf(c.conn, strings.Join(stats, "\n")); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/vendor/github.com/quipo/statsd/event/gauge.go
+++ b/vendor/github.com/quipo/statsd/event/gauge.go
@@ -15,7 +15,7 @@ func (e *Gauge) Update(e2 Event) error {
 	if e.Type() != e2.Type() {
 		return fmt.Errorf("statsd event type conflict: %s vs %s ", e.String(), e2.String())
 	}
-	e.Value += e2.Payload().(int64)
+	e.Value = e2.Payload().(int64)
 	return nil
 }
 

--- a/vendor/github.com/quipo/statsd/event/gaugedelta.go
+++ b/vendor/github.com/quipo/statsd/event/gaugedelta.go
@@ -35,7 +35,7 @@ func (e GaugeDelta) Stats() []string {
 			fmt.Sprintf("%s:%d|g", e.Name, e.Value),
 		}
 	}
-	return []string{fmt.Sprintf("%s:%d|g", e.Name, e.Value)}
+	return []string{fmt.Sprintf("%s:+%d|g", e.Name, e.Value)}
 }
 
 // Key returns the name of this metric

--- a/vendor/github.com/quipo/statsd/event/precisiontiming.go
+++ b/vendor/github.com/quipo/statsd/event/precisiontiming.go
@@ -40,7 +40,7 @@ func (e PrecisionTiming) Payload() interface{} {
 // Stats returns an array of StatsD events as they travel over UDP
 func (e PrecisionTiming) Stats() []string {
 	return []string{
-		fmt.Sprintf("%s.count:%d|a", e.Name, e.Count),
+		fmt.Sprintf("%s.count:%d|c", e.Name, e.Count),
 		fmt.Sprintf("%s.avg:%.6f|ms", e.Name, float64(int64(e.Value)/e.Count)/1000000), // make sure e.Count != 0
 		fmt.Sprintf("%s.min:%.6f|ms", e.Name, e.durationToMs(e.Min)),
 		fmt.Sprintf("%s.max:%.6f|ms", e.Name, e.durationToMs(e.Max)),

--- a/vendor/github.com/quipo/statsd/event/timing.go
+++ b/vendor/github.com/quipo/statsd/event/timing.go
@@ -42,7 +42,7 @@ func (e Timing) Payload() interface{} {
 // Stats returns an array of StatsD events as they travel over UDP
 func (e Timing) Stats() []string {
 	return []string{
-		fmt.Sprintf("%s.count:%d|a", e.Name, e.Count),
+		fmt.Sprintf("%s.count:%d|c", e.Name, e.Count),
 		fmt.Sprintf("%s.avg:%d|ms", e.Name, int64(e.Value/e.Count)), // make sure e.Count != 0
 		fmt.Sprintf("%s.min:%d|ms", e.Name, e.Min),
 		fmt.Sprintf("%s.max:%d|ms", e.Name, e.Max),

--- a/vendor/github.com/quipo/statsd/interface.go
+++ b/vendor/github.com/quipo/statsd/interface.go
@@ -5,6 +5,7 @@ import "time"
 // Statsd is an interface to a StatsD client (buffered/unbuffered)
 type Statsd interface {
 	CreateSocket() error
+	CreateTCPSocket() error
 	Close() error
 	Incr(stat string, count int64) error
 	Decr(stat string, count int64) error

--- a/vendor/github.com/quipo/statsd/noopclient.go
+++ b/vendor/github.com/quipo/statsd/noopclient.go
@@ -14,6 +14,11 @@ func (s NoopClient) CreateSocket() error {
 	return nil
 }
 
+// CreateTCPSocket does nothing
+func (s NoopClient) CreateTCPSocket() error {
+	return nil
+}
+
 // Close does nothing
 func (s NoopClient) Close() error {
 	return nil


### PR DESCRIPTION
This pull request introduces a new flag, `statsdProtocol` for controlling the statsd client protocol. The choice is between `udp` and `tcp`.

